### PR TITLE
DBI-1080 Updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ So you have to install native tools for getting raw logs.
 2. adb
   - `brew install android-platform-tools`
 3. idevicesyslog
-  - `brew install libimobiledevice`
+  - `brew install --HEAD libimobiledevice`
 4. python3
   - `brew install python3`
 


### PR DESCRIPTION
MacOS에서 brew를 통해 libimobiledevice의 stable version을 설치하면 최신 버전 iOS 기기와 연결이 안 되는 문제가 있습니다. --HEAD 옵션을 추가하도록 합니다.